### PR TITLE
Fix typos discovered by codespell

### DIFF
--- a/create_protobuf.py
+++ b/create_protobuf.py
@@ -21,7 +21,7 @@ def main() -> int:
     # Fetch protocol file.
     resp = urlopen(PROTOCOL_FILE_URL)
     if resp.status != 200:
-        sys.stderr.write("Failed to fetch protcol file.\n")
+        sys.stderr.write("Failed to fetch protocol file.\n")
         return 1
     proto_dir = Path(tempfile.mkdtemp())
     proto_path = proto_dir / "embedded_sass.proto"

--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -8,7 +8,7 @@ Usage guide
    When you install by sdist, none-any bdist or source,
    you need to install it manually.
 
-There are some usage for ``sass-embbedded``.
+There are some usage for ``sass-embedded``.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/usage/protocol.rst
+++ b/docs/usage/protocol.rst
@@ -12,7 +12,7 @@ Currently, this project supports low-level protocol access.
    **Under construction**
 
    This API will be implemented to work correctly,
-   but it is only to send and recieve protobuf message.
+   but it is only to send and receive protobuf message.
 
    If you want to know usage now, See `example code`_.
 

--- a/src/sass_embedded/protocol/compiler.py
+++ b/src/sass_embedded/protocol/compiler.py
@@ -99,7 +99,7 @@ class Host:
         # Sending packet.
         packet = self.make_packet(message)
         self._proc.stdin.write(packet.to_bytes())  # type: ignore[union-attr]
-        # Recieve packet.
+        # Receive packet.
         out = b""
         idx = 0
         length = 0

--- a/src/sass_embedded/simple.py
+++ b/src/sass_embedded/simple.py
@@ -140,9 +140,9 @@ def compile_string(
 ) -> Result[str]:
     """Convert from Sass/SCSS source to CSS.
 
-    :param srouce: Source text. It must be format for Sass or SCSS.
+    :param source: Source text. It must be format for Sass or SCSS.
     :param syntax: Source format.
-    :param load_paths: List of addtional load path for Sass compile.
+    :param load_paths: List of additional load path for Sass compile.
     :param style: Output style.
     :param embed_sourcemap: Flag to embed source-map into output.
     :param embed_sources: Flag to embed sources into output. It works only when ``embed_sourcemap`` is ``True``.
@@ -181,7 +181,7 @@ def compile_file(
 
     :param source: Source path. It must have extension ``.sass``, ``.scss`` or ``.css``.
     :param dest: Output destination.
-    :param load_paths: List of addtional load path for Sass compile.
+    :param load_paths: List of additional load path for Sass compile.
     :param style: Output style.
     :param no_sourcemap: Flag to skip generating source-map.
     :param embed_sourcemap: Flag to embed source-map into output.
@@ -227,7 +227,7 @@ def compile_directory(
 
     :param source: Source path. It must have extension ``.sass``, ``.scss`` or ``.css``.
     :param dest: Output destination.
-    :param load_paths: List of addtional load path for Sass compile.
+    :param load_paths: List of additional load path for Sass compile.
     :param style: Output style.
     :param no_sourcemap: Flag to skip generating source-maps.
     :param embed_sourcemap: Flag to embed source-map into output.

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -174,8 +174,8 @@ class TestFor_compile_directory:
         cmp = filecmp.dircmp(output, expected)
         output_files = list(Path(output).glob("*.css"))
         output_maps = list(Path(output).glob("*.css.map"))
-        expexted_files = list(Path(expected).glob("*"))
-        assert len(expexted_files) == len(output_files)
+        expected_files = list(Path(expected).glob("*"))
+        assert len(expected_files) == len(output_files)
         assert len(output_files) == len(output_maps)
         assert cmp.left_only == sorted([f.name for f in output_maps])
 
@@ -184,8 +184,8 @@ class TestFor_compile_directory:
         M.compile_directory(source, output, no_sourcemap=True)
         output_files = list(Path(output).glob("*.css"))
         output_maps = list(Path(output).glob("*.css.map"))
-        expexted_files = list(Path(expected).glob("*"))
-        assert len(expexted_files) == len(output_files)
+        expected_files = list(Path(expected).glob("*"))
+        assert len(expected_files) == len(output_files)
         assert not output_maps
 
     def test_with_embed_sourcemap(self, tmpdir: Path):
@@ -193,8 +193,8 @@ class TestFor_compile_directory:
         M.compile_directory(source, output, embed_sourcemap=True)
         output_files = list(Path(output).glob("*.css"))
         output_maps = list(Path(output).glob("*.css.map"))
-        expexted_files = list(Path(expected).glob("*"))
-        assert len(expexted_files) == len(output_files)
+        expected_files = list(Path(expected).glob("*"))
+        assert len(expected_files) == len(output_files)
         assert not output_maps
 
     def test_with_embed_sources(self, tmpdir: Path):


### PR DESCRIPTION
Fix typos discovered by codespell - https://pypi.org/project/codespell

% `codespell`
```
./create_protobuf.py:24: protcol ==> protocol
./docs/usage/protocol.rst:15: recieve ==> receive
./src/sass_embedded/simple.py:143: srouce ==> source
./src/sass_embedded/simple.py:145: addtional ==> additional
./src/sass_embedded/simple.py:184: addtional ==> additional
./src/sass_embedded/simple.py:230: addtional ==> additional
./src/sass_embedded/protocol/compiler.py:102: Recieve ==> Receive
```
% `codespell --write-changes` 