### PR TITLE
Resolve aarch64 as arm64 (#39)

### DIFF
--- a/src/sass_embedded/dart_sass/__init__.py
+++ b/src/sass_embedded/dart_sass/__init__.py
@@ -41,6 +41,9 @@ def resolve_arch() -> ArchName:
         arch_name = "x64"
     if arch_name.startswith("arm") and arch_name != "arm64":
         arch_name = "arm"
+    if arch_name == 'aarch64':
+        # see https://github.com/attakei/sass-embedded-python/issues/39
+        arch_name = 'arm64'
     return arch_name  # type: ignore[return-value]
 
 


### PR DESCRIPTION
This PR fixes #39 by resolving `aarch64` as `arm64`, which fixes the lib not being able to find the `dart` exe being installed.


See #39 for more details around the issue