### PR TITLE
feat: Select musl Dart Sass variant on musllinux runtimes

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -102,6 +102,8 @@ jobs:
       image: '${{ matrix.image }}'
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: 'Run test'
         env:
           EXPECTED_OS: 'linux'
@@ -120,15 +122,15 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { runner: 'ubuntu-latest',    expected_os: 'linux',   expected_arch: 'x64'   }
-          - { runner: 'ubuntu-24.04-arm', expected_os: 'linux',   expected_arch: 'arm64' }
-          - { runner: 'windows-latest',   expected_os: 'windows', expected_arch: 'x64'   }
+          - { runner: 'ubuntu-latest',    expected_os: 'linux',   expected_arch: 'x64',   expected_libc: 'gnu' }
+          - { runner: 'ubuntu-24.04-arm', expected_os: 'linux',   expected_arch: 'arm64', expected_libc: 'gnu' }
+          - { runner: 'windows-latest',   expected_os: 'windows', expected_arch: 'x64',   expected_libc: 'gnu' }
           # TODO: Re-enable when Windows-on-ARM share warrants arch detection work.
           # uv installs x64 Python on windows-11-arm, so platform.machine() reports AMD64
           # under emulation and resolve_arch() returns 'x64' instead of 'arm64'.
           # Reactivate once we add Windows-on-ARM emulation handling (see NOTES_windows-arm.md).
           # - { runner: 'windows-11-arm',   expected_os: 'windows', expected_arch: 'arm64' }
-          - { runner: 'macos-latest',     expected_os: 'macos',   expected_arch: 'arm64' }
+          - { runner: 'macos-latest',     expected_os: 'macos',   expected_arch: 'arm64', expected_libc: 'gnu' }
           # TODO: Re-enable when macOS x64 hosted runner availability stabilizes.
           # macos-13 jobs frequently stay in status=queued for hours because the Intel
           # macOS hosted runner pool is small; timeout-minutes does not cover queue time
@@ -153,6 +155,7 @@ jobs:
         env:
           EXPECTED_OS: ${{ matrix.expected_os }}
           EXPECTED_ARCH: ${{ matrix.expected_arch }}
+          EXPECTED_LIBC: ${{ matrix.expected_libc }}
         run: |
           uv run pytest tests/test_env_dispatch.py -v
   doc-test:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -88,22 +88,28 @@ jobs:
       - name: 'Run test'
         run: |
           uv run pytest
-  manylinux-test:
+  linux-libc-test:
     needs: 'lint'
     runs-on: 'ubuntu-latest'
     strategy:
+      fail-fast: false
       max-parallel: 4
       matrix:
-        image:
-          - 'quay.io/pypa/manylinux2014_x86_64'
+        include:
+          - { image: 'quay.io/pypa/manylinux_2_28_x86_64', expected_libc: 'gnu'  }
+          - { image: 'quay.io/pypa/musllinux_1_2_x86_64',  expected_libc: 'musl' }
     container:
       image: '${{ matrix.image }}'
     steps:
-      - run: |
+      - uses: actions/checkout@v7
+      - name: 'Run test'
+        env:
+          EXPECTED_OS: 'linux'
+          EXPECTED_ARCH: 'x64'
+          EXPECTED_LIBC: '${{ matrix.expected_libc }}'
+        run: |
           curl -LsSf https://astral.sh/uv/install.sh | sh
           source $HOME/.local/bin/env
-          git clone https://github.com/attakei-lab/sass-embedded-python /opt/repo
-          cd /opt/repo
           uv run python -m sass_embedded.dart_sass
           uv run pytest
   env-coverage-test:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "bbpb>=1.4.2",
+    "packaging>=25.0",
     "protobuf>=6.33.0",
 ]
 

--- a/src/sass_embedded/dart_sass/__init__.py
+++ b/src/sass_embedded/dart_sass/__init__.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from packaging.tags import sys_tags
+
 from .._const import DART_SASS_VERSION
 
 if TYPE_CHECKING:
@@ -41,10 +43,17 @@ def resolve_arch() -> ArchName:
         arch_name = "x64"
     if arch_name.startswith("arm") and arch_name != "arm64":
         arch_name = "arm"
-    if arch_name == 'aarch64':
+    if arch_name == "aarch64":
         # see https://github.com/attakei/sass-embedded-python/issues/39
-        arch_name = 'arm64'
+        arch_name = "arm64"
     return arch_name  # type: ignore[return-value]
+
+
+def resolve_musl() -> bool:
+    """Detect whether current Python runtime is musl-based."""
+    if platform.system() != "Linux":
+        return False
+    return any("musllinux" in t.platform for t in sys_tags())
 
 
 @dataclass
@@ -60,17 +69,29 @@ class Release:
     """Identify of CPU architecture."""
     version: str = DART_SASS_VERSION
     """Versionstring of Dart Sass."""
+    is_musl: bool = False
+    """Whether the target Linux uses musl libc."""
+
+    def __post_init__(self):
+        if self.is_musl and self.os != "linux":
+            raise ValueError(
+                f"is_musl=True is only valid for os='linux', got os={self.os!r}"
+            )
+
+    @property
+    def _libc_suffix(self) -> str:
+        return "-musl" if self.is_musl else ""
 
     @property
     def fullname(self) -> str:
         """Full name of release's directory."""
-        return f"{self.version}-{self.os}-{self.arch}"
+        return f"{self.version}-{self.os}-{self.arch}{self._libc_suffix}"
 
     @property
     def archive_url(self) -> str:
         """URL for archive of GitHub Releases."""
         ext = "zip" if self.os == "windows" else "tar.gz"
-        return f"https://github.com/sass/dart-sass/releases/download/{self.version}/dart-sass-{self.version}-{self.os}-{self.arch}.{ext}"
+        return f"https://github.com/sass/dart-sass/releases/download/{self.version}/dart-sass-{self.version}-{self.os}-{self.arch}{self._libc_suffix}.{ext}"
 
     @property
     def archive_format(self) -> str:
@@ -82,7 +103,8 @@ class Release:
         """Create object with current environment and registered version."""
         os_name = resolve_os()
         arch_name = resolve_arch()
-        return cls(os=os_name, arch=arch_name)
+        is_musl = resolve_musl() if os_name == "linux" else False
+        return cls(os=os_name, arch=arch_name, is_musl=is_musl)
 
     def resolve_dir(self, base_dir: Path):
         """Retrieve full path of release's directory."""

--- a/src/sass_embedded/dart_sass/installer.py
+++ b/src/sass_embedded/dart_sass/installer.py
@@ -27,16 +27,30 @@ def clean():
     shutil.rmtree(resolve_bin_base_dir(), ignore_errors=True)
 
 
-def install(os_name: Optional[str] = None, arch_name: Optional[str] = None):
+def install(
+    os_name: Optional[str] = None,
+    arch_name: Optional[str] = None,
+    is_musl: Optional[bool] = None,
+):
     """Install Dart Sass executable.
 
     :param os_name: Target OS of archives.
     :param arch_name: Target CPU architecture of archives.
+    :param is_musl: Force musl variant on or off (Linux only).
     """
-    if os_name and arch_name:
-        release = Release(os=os_name, arch=arch_name)  # type: ignore[arg-type]
-    else:
-        release = Release.init()
+    base = Release.init()
+    target_os = os_name or base.os
+    target_arch = arch_name or base.arch
+    target_musl = (
+        is_musl
+        if is_musl is not None
+        else (base.is_musl if target_os == base.os else False)
+    )
+    release = Release(
+        os=target_os,  # type: ignore[arg-type]
+        arch=target_arch,  # type: ignore[arg-type]
+        is_musl=target_musl,
+    )
     release_dir = release.resolve_dir(resolve_bin_base_dir())
     logging.debug(f"Find '{release_dir}'")
     if release_dir.exists() and (release_dir / "src").exists():

--- a/src/sass_embedded/dart_sass/installer.py
+++ b/src/sass_embedded/dart_sass/installer.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from urllib.request import urlopen
 
-from . import Release, resolve_bin_base_dir
+from . import Release, resolve_arch, resolve_bin_base_dir, resolve_musl, resolve_os
 
 if TYPE_CHECKING:
     from typing import Optional
@@ -38,19 +38,16 @@ def install(
     :param arch_name: Target CPU architecture of archives.
     :param is_musl: Force musl variant on or off (Linux only).
     """
-    base = Release.init()
-    target_os = os_name or base.os
-    target_arch = arch_name or base.arch
-    target_musl = (
-        is_musl
-        if is_musl is not None
-        else (base.is_musl if target_os == base.os else False)
-    )
-    release = Release(
-        os=target_os,  # type: ignore[arg-type]
-        arch=target_arch,  # type: ignore[arg-type]
-        is_musl=target_musl,
-    )
+    if os_name is None and arch_name is None and is_musl is None:
+        release = Release.init()
+    else:
+        if os_name is None:
+            os_name = resolve_os()
+        if arch_name is None:
+            arch_name = resolve_arch()
+        if is_musl is None:
+            is_musl = resolve_musl()
+        release = Release(os=os_name, arch=arch_name, is_musl=is_musl)
     release_dir = release.resolve_dir(resolve_bin_base_dir())
     logging.debug(f"Find '{release_dir}'")
     if release_dir.exists() and (release_dir / "src").exists():

--- a/tests/test_dart_sass.py
+++ b/tests/test_dart_sass.py
@@ -12,6 +12,44 @@ def test_relasename():
     assert bin_dir.parent.name == "_ext"
 
 
+def test_release_with_musl_suffix():
+    r = P.Release("linux", "x64", is_musl=True)
+    assert r.fullname == f"{DART_SASS_VERSION}-linux-x64-musl"
+    assert r.archive_url.endswith(
+        f"dart-sass-{DART_SASS_VERSION}-linux-x64-musl.tar.gz"
+    )
+
+
+def test_release_rejects_musl_on_non_linux():
+    with pytest.raises(ValueError):
+        P.Release("macos", "arm64", is_musl=True)
+
+
+def test_release_init_picks_up_musl(monkeypatch):
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(P.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(P, "resolve_arch", lambda: "x64")
+    monkeypatch.setattr(
+        P, "sys_tags", lambda: [SimpleNamespace(platform="musllinux_1_2_x86_64")]
+    )
+    r = P.Release.init()
+    assert r.os == "linux"
+    assert r.is_musl is True
+
+
+def test_release_init_no_musl_on_glibc(monkeypatch):
+    from types import SimpleNamespace
+
+    monkeypatch.setattr(P.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(P, "resolve_arch", lambda: "x64")
+    monkeypatch.setattr(
+        P, "sys_tags", lambda: [SimpleNamespace(platform="manylinux_2_28_x86_64")]
+    )
+    r = P.Release.init()
+    assert r.is_musl is False
+
+
 @pytest.mark.skipif('sys.platform != "linux"')
 def test_linux_release_object():
     r = P.Release.init()

--- a/tests/test_env_dispatch.py
+++ b/tests/test_env_dispatch.py
@@ -16,6 +16,7 @@ from sass_embedded.dart_sass.installer import install
 
 EXPECTED_OS = os.environ.get("EXPECTED_OS")
 EXPECTED_ARCH = os.environ.get("EXPECTED_ARCH")
+EXPECTED_LIBC = os.environ.get("EXPECTED_LIBC")
 
 pytestmark = pytest.mark.skipif(
     not (EXPECTED_OS and EXPECTED_ARCH),
@@ -23,22 +24,31 @@ pytestmark = pytest.mark.skipif(
 )
 
 
+def _expected_libc_suffix() -> str:
+    return "-musl" if EXPECTED_LIBC == "musl" else ""
+
+
 def test_release_init_matches_runner():
     r = P.Release.init()
     assert r.os == EXPECTED_OS
     assert r.arch == EXPECTED_ARCH
+    if EXPECTED_LIBC is not None:
+        assert r.is_musl is (EXPECTED_LIBC == "musl")
 
 
 def test_archive_url_encodes_target():
     r = P.Release.init()
-    assert f"-{EXPECTED_OS}-{EXPECTED_ARCH}." in r.archive_url
+    assert f"-{EXPECTED_OS}-{EXPECTED_ARCH}{_expected_libc_suffix()}." in r.archive_url
 
 
 def test_binary_installation_for_runner():
     install()
     r = P.Release.init()
     bin_dir = r.resolve_dir(P.resolve_bin_base_dir())
-    assert bin_dir.name == f"{DART_SASS_VERSION}-{EXPECTED_OS}-{EXPECTED_ARCH}"
+    assert (
+        bin_dir.name
+        == f"{DART_SASS_VERSION}-{EXPECTED_OS}-{EXPECTED_ARCH}{_expected_libc_suffix()}"
+    )
     e = r.get_executable()
     assert e.dart_vm_path.exists()
     assert e.sass_snapshot_path.exists()

--- a/tests/test_env_dispatch.py
+++ b/tests/test_env_dispatch.py
@@ -19,8 +19,8 @@ EXPECTED_ARCH = os.environ.get("EXPECTED_ARCH")
 EXPECTED_LIBC = os.environ.get("EXPECTED_LIBC")
 
 pytestmark = pytest.mark.skipif(
-    not (EXPECTED_OS and EXPECTED_ARCH),
-    reason="EXPECTED_OS/EXPECTED_ARCH not set",
+    not (EXPECTED_OS and EXPECTED_ARCH and EXPECTED_LIBC),
+    reason="EXPECTED_OS/EXPECTED_ARCH/EXPECTED_LIBC not set",
 )
 
 
@@ -32,8 +32,7 @@ def test_release_init_matches_runner():
     r = P.Release.init()
     assert r.os == EXPECTED_OS
     assert r.arch == EXPECTED_ARCH
-    if EXPECTED_LIBC is not None:
-        assert r.is_musl is (EXPECTED_LIBC == "musl")
+    assert r.is_musl is (EXPECTED_LIBC == "musl")
 
 
 def test_archive_url_encodes_target():

--- a/uv.lock
+++ b/uv.lock
@@ -726,6 +726,7 @@ version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "bbpb" },
+    { name = "packaging" },
     { name = "protobuf", version = "6.33.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.10'" },
     { name = "protobuf", version = "7.35.1", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.10'" },
 ]
@@ -764,6 +765,7 @@ docs-dev = [
 [package.metadata]
 requires-dist = [
     { name = "bbpb", specifier = ">=1.4.2" },
+    { name = "packaging", specifier = ">=25.0" },
     { name = "protobuf", specifier = ">=6.33.0" },
 ]
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux musl support, updating release naming, download URLs, and installed artifact paths to include the correct `-musl` variant.
  * Improved runtime detection so Linux automatically selects the appropriate glibc vs musl Dart Sass artifact.

* **Bug Fixes**
  * Correctly installs the libc-specific package for Linux environments to match the detected libc.

* **Tests**
  * Expanded coverage for musl-specific release naming, URL generation, and environment-driven detection.

* **Chores**
  * Updated CI job matrices to validate libc/OS/architecture combinations, and added `packaging>=25.0` as a runtime dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->